### PR TITLE
docs: correct database name in spring-mysql-redis readme

### DIFF
--- a/spring-mysql-redis/README.md
+++ b/spring-mysql-redis/README.md
@@ -25,7 +25,7 @@ mvn clean install
 
 ### 3. Set Up Docker Containers
 
-#### PostgreSQL Container
+#### MySQL Container
 
 1. Pull the MySQL Docker Image:
 


### PR DESCRIPTION
## Description

This pull request addresses a documentation error in the `spring-mysql-redis/README.md` file.

The setup guide for the Docker container incorrectly had a heading for "PostgreSQL" when all the associated commands and the application itself are configured for MySQL. This change corrects the heading to "MySQL" to provide clarity and prevent confusion for developers using this sample.

This fixes a minor documentation bug.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

## How Has This Been Tested?

This is a documentation-only change. The fix can be verified with the following steps:

1.  Navigate to the `spring-mysql-redis` directory.
2.  Open the `README.md` file.
3.  Confirm that the heading for the database setup now correctly reads `#### MySQL Container`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [x] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.