### PR TITLE
fix(ps-cache-kotlin): use psql -c instead of heredoc for schema setup

### DIFF
--- a/ps-cache-kotlin/README.md
+++ b/ps-cache-kotlin/README.md
@@ -59,17 +59,19 @@ docker run -d --name pg-demo \
   -e POSTGRES_DB=testdb \
   -p 5432:5432 postgres:16
 
+# Wait for Postgres to be ready
+sleep 3
+
 # Create the schema and seed data
-docker exec pg-demo psql -U postgres -d testdb -f- <<'SQL'
-CREATE SCHEMA IF NOT EXISTS travelcard;
-CREATE TABLE IF NOT EXISTS travelcard.travel_account (
+docker exec pg-demo psql -U postgres -d testdb -c "
+  CREATE SCHEMA IF NOT EXISTS travelcard;
+  CREATE TABLE IF NOT EXISTS travelcard.travel_account (
     id SERIAL PRIMARY KEY, member_id INT NOT NULL UNIQUE,
     name TEXT NOT NULL, balance INT NOT NULL DEFAULT 0);
-INSERT INTO travelcard.travel_account (member_id, name, balance) VALUES
+  INSERT INTO travelcard.travel_account (member_id, name, balance) VALUES
     (19, 'Alice', 1000), (23, 'Bob', 2500),
     (31, 'Charlie', 500), (42, 'Diana', 7500)
-ON CONFLICT (member_id) DO NOTHING;
-SQL
+  ON CONFLICT (member_id) DO NOTHING;"
 
 # Build
 mvn package -DskipTests -q


### PR DESCRIPTION
## Summary
The `docker exec ... psql -f- <<'SQL'` heredoc in the README doesn't work because `docker exec` doesn't forward stdin from heredocs by default. Replaced with `psql -c "..."` which works in all shells.

Also added `sleep 3` after `docker run` to wait for Postgres readiness before running schema setup.

## Test plan
- [ ] Run the standalone setup commands from the README on a fresh machine