### PR TITLE
chore: use released Java SDK in dedup sample

### DIFF
--- a/java-dedup/README.md
+++ b/java-dedup/README.md
@@ -9,11 +9,10 @@ The Java SDK reads JaCoCo coverage in-process via `org.jacoco.agent.rt.RT.getAge
 ## Setup
 
 ```bash
-(cd ../../java-sdk && mvn -B -DskipTests -Dgpg.skip=true clean install -pl keploy-sdk -am)
 mvn -B -DskipTests clean package
 ```
 
-This installs the sibling SDK snapshot locally, builds the sample, produces `target/java-dedup-0.0.1-SNAPSHOT.jar`, and copies `target/jacocoagent.jar` next to it.
+This builds the sample against the released Keploy Java SDK, produces `target/java-dedup-0.0.1-SNAPSHOT.jar`, and copies `target/jacocoagent.jar` next to it.
 
 ## Run dedup natively
 

--- a/java-dedup/pom.xml
+++ b/java-dedup/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <keploy.sdk.version>0.0.1-SNAPSHOT</keploy.sdk.version>
+        <keploy.sdk.version>2.0.0</keploy.sdk.version>
         <jacoco.version>0.8.12</jacoco.version>
     </properties>
 


### PR DESCRIPTION
This pull request updates the `java-dedup` sample to use the released Keploy Java SDK version 2.0.0 instead of a local snapshot build. It also clarifies the setup instructions to reflect this change.

Dependency update:

* Updated the `keploy.sdk.version` property in `pom.xml` from `0.0.1-SNAPSHOT` to `2.0.0` to use the released SDK instead of a local snapshot.

Documentation update:

* Changed the setup instructions in `README.md` to remove the step for building the SDK locally and clarified that the sample is now built against the released Keploy Java SDK.