### PR TITLE
Add spring-aerospike: Aerospike-Java sample with Keploy record/replay

### DIFF
--- a/spring-aerospike/.gitignore
+++ b/spring-aerospike/.gitignore
@@ -1,0 +1,2 @@
+target/
+keploy/

--- a/spring-aerospike/Dockerfile
+++ b/spring-aerospike/Dockerfile
@@ -1,0 +1,8 @@
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+RUN apt-get update && apt-get install -y maven && rm -rf /var/lib/apt/lists/*
+COPY pom.xml /app/
+COPY src /app/src
+RUN mvn -q -DskipTests package
+EXPOSE 8090
+ENTRYPOINT ["java", "-jar", "target/spring-aerospike.jar"]

--- a/spring-aerospike/README.md
+++ b/spring-aerospike/README.md
@@ -1,0 +1,144 @@
+# spring-aerospike — Aerospike-Java sample with Keploy record/replay
+
+A Spring Boot 2.7 service that talks to Aerospike CE over the
+clear-text service port (3000) using the official
+`aerospike-client-jdk8`. Recorded and replayed end-to-end with
+Keploy via three bundled scripts that mirror the
+`keploy/samples-go/aerospike-tls` shape one-to-one — same endpoints,
+same test-set layout, same record-then-replay loop.
+
+What the sample demonstrates:
+
+* **Keploy records binary Aerospike protocol traffic** — Info,
+  AS_MSG (single-record PUT/GET/TOUCH/DELETE), BATCH_READ/WRITE,
+  SCAN, QUERY, UDF, CDT — and replays them from `mocks.yaml`
+  without needing the real cluster.
+* **Replay stays deterministic at any concurrency the app exposes** —
+  single-client `/parallel`, multi-client round-robin, and per-
+  request fresh-client construction all pass cleanly.
+* **A pipeline-friendly shape.** Three `scripts/script-{1,2,3}.sh`
+  entry points each record and replay one test-set independently,
+  so a CI matrix can call them as separate steps.
+
+## Layout
+
+```
+spring-aerospike/
+├── pom.xml                            # Spring Boot 2.7 + aerospike-client-jdk8
+├── src/main/java/com/example/aerospike/
+│   ├── SpringAerospikeApplication.java
+│   ├── config/                        # client + multi-client pool, warmup, policies
+│   └── controller/                    # one @RestController per endpoint group
+├── src/main/resources/
+│   └── application.properties         # port + Aerospike host/namespace/pool sizing
+├── aerospike-conf/
+│   └── aerospike.conf                 # CE config: clear-text on 3000
+├── docker-compose.yml                 # Aerospike CE + the Spring Boot app
+├── Dockerfile                         # eclipse-temurin 17 + mvn package
+├── keploy.yml                         # Keploy CLI config (command, ports)
+└── scripts/
+    ├── common.sh                      # shared boot/build/record/replay/normalise
+    ├── script-1.sh                    # records + replays test-set-0 (CRUD)
+    ├── script-2.sh                    # records + replays test-set-1 (/parallel)
+    └── script-3.sh                    # records + replays test-set-2 (/multiclient + /freshclient)
+```
+
+There is no committed `keploy/` directory — the scripts produce it
+from scratch every run. Each CI run validates the full
+record-then-replay loop instead of replaying stale captures.
+
+## Endpoints
+
+| Method | Path                       | What it does                                                                 |
+| ------ | -------------------------- | ---------------------------------------------------------------------------- |
+| GET    | `/health`                  | `info build + namespaces`                                                    |
+| POST   | `/put`                     | single-record PUT                                                            |
+| GET    | `/get/{key}`               | single-record GET                                                            |
+| POST   | `/batch/put`               | sequential write loop                                                        |
+| GET    | `/batch/get?k=a&k=b`       | BATCH_READ                                                                   |
+| POST   | `/scan`                    | full namespace scan                                                          |
+| POST   | `/query`                   | secondary-index range query                                                  |
+| POST   | `/udf`                     | UDF_EXECUTE                                                                  |
+| POST   | `/cdt/list/append`         | CDT list append                                                              |
+| POST   | `/cdt/map/put`             | CDT map put                                                                  |
+| POST   | `/touch/{key}`             | TOUCH                                                                        |
+| DELETE | `/key/{key}`               | DELETE                                                                       |
+| POST   | `/parallel?n=N&prefix=P`   | fans out N threads, each PUT+GET on a unique key — **one shared client**     |
+| POST   | `/multiclient?n=N&prefix=P`| same, but round-robins across **4 pre-built `AerospikeClient` instances**    |
+| POST   | `/freshclient?n=N&prefix=P`| **each thread builds its own `AerospikeClient`** inside the request          |
+
+## Run it manually
+
+```bash
+# 1) Boot Aerospike CE on clear-text 3000.
+docker compose up -d aerospike
+
+# 2) Build + run the Spring Boot app.
+mvn -q -DskipTests package
+java -jar target/spring-aerospike.jar
+
+# 3) Hit it.
+curl -s localhost:8090/health
+curl -s -XPOST localhost:8090/put -H 'Content-Type: application/json' \
+     -d '{"key":"alice","bins":{"age":30}}'
+curl -s localhost:8090/get/alice
+curl -s -XPOST 'localhost:8090/parallel?n=24&prefix=run1'
+curl -s -XPOST 'localhost:8090/multiclient?n=24&prefix=mc1'
+curl -s -XPOST 'localhost:8090/freshclient?n=8&prefix=fc1'
+```
+
+## Record + replay with the scripts
+
+```bash
+# Each script is self-contained: brings up Aerospike, builds the
+# JAR, records, replays. Exit code is non-zero if any case fails on
+# replay.
+sudo ./scripts/script-1.sh    # test-set-0: single-endpoint CRUD
+sudo ./scripts/script-2.sh    # test-set-1: /parallel n = 4..24
+sudo ./scripts/script-3.sh    # test-set-2: /multiclient + /freshclient
+```
+
+Pipeline-friendly knobs (env vars):
+
+| Var          | Default       | What it does                                                  |
+|--------------|---------------|---------------------------------------------------------------|
+| `KEPLOY`     | `sudo keploy` | binary + auth invocation. Override to `keploy` if root        |
+| `PORT`       | `8090`        | HTTP port the recorded sample listens on                      |
+| `LOG_DIR`    | `/tmp`        | where to drop the keploy record log                           |
+| `SKIP_DOCKER`| (unset)       | `=1` skips `docker compose up -d aerospike` (already running) |
+| `SKIP_BUILD` | (unset)       | `=1` skips `mvn package` (JAR already in target/)             |
+
+## Concurrency notes — why the warmup + retry matter
+
+Mocked replay through Keploy is roughly 10–20× faster than real
+Aerospike for the same op. A burst of N concurrent threads on a
+cold client pool then races to open N fresh sockets, and the
+thread that loses the race surfaces as `MAX_RETRIES_EXCEEDED` at
+the application — even though every peer in the same burst
+succeeds.
+
+`AerospikeConfig` paints over this with four layered changes;
+together they make `/parallel?n=24`, `/multiclient?n=24`, and
+`/freshclient?n=8` replay clean on every run:
+
+1. **Sized pool** — `ClientPolicy.maxConnsPerNode = 256`. The
+   `OpeningConnectionThreshold` analogue is kept low (16) so a
+   sudden burst doesn't outpace upstream connect rate.
+2. **Tolerant per-op policy** — `Policies.parallelWrite()` and
+   `Policies.parallelRead()` set `socketTimeout 10s`, `totalTimeout
+   30s`, `maxRetries 10`, `sleepBetweenRetries 5ms`.
+3. **Two-phase warmup** on the main client at startup: a sequential
+   prelude that walks the cluster past cold-start latencies,
+   followed by a parallel fill that puts idle connections in the
+   pool before the HTTP server accepts the first request.
+4. **App-level retry wrapper** (`RetryHelper.doOp`) around each PUT
+   and GET in `/parallel`, `/multiclient`, and `/freshclient`.
+
+`/multiclient`'s extra clients are deliberately NOT warmed at
+startup — a hundred concurrent dials at boot can stall a record-
+time proxy. The retry wrapper covers their first burst instead.
+
+This sample is the Java counterpart of
+[`keploy/samples-go/aerospike-tls`](https://github.com/keploy/samples-go/tree/main/aerospike-tls);
+the script set is byte-for-byte the same shape so a single CI
+matrix can drive both languages with the same harness.

--- a/spring-aerospike/aerospike-conf/aerospike.conf
+++ b/spring-aerospike/aerospike-conf/aerospike.conf
@@ -1,0 +1,45 @@
+# Aerospike CE config — clear-text on port 3000.
+
+service {
+    proto-fd-max 15000
+    cluster-name spring-aerospike-sample
+}
+
+logging {
+    console {
+        context any info
+    }
+}
+
+network {
+    service {
+        address any
+        port 3000
+    }
+
+    heartbeat {
+        mode mesh
+        address local
+        port 3002
+        interval 150
+        timeout 10
+    }
+
+    fabric {
+        address local
+        port 3001
+    }
+
+    info {
+        port 3003
+    }
+}
+
+namespace test {
+    replication-factor 1
+    default-ttl 30d
+    nsup-period 120
+    storage-engine memory {
+        data-size 1G
+    }
+}

--- a/spring-aerospike/docker-compose.yml
+++ b/spring-aerospike/docker-compose.yml
@@ -1,0 +1,42 @@
+# Aerospike CE on clear-text 3000 + the Spring Boot sample on 8090.
+services:
+  aerospike:
+    image: aerospike/aerospike-server:7.2.0.1
+    container_name: aerospike
+    networks:
+      - keploy-network
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./aerospike-conf/aerospike.conf:/etc/aerospike/aerospike.conf:ro
+    entrypoint: ["/usr/bin/asd", "--foreground", "--config-file", "/etc/aerospike/aerospike.conf"]
+    command: []
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
+    healthcheck:
+      test: ["CMD", "asinfo", "-h", "127.0.0.1", "-p", "3000", "-v", "build"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: spring-aerospike
+    depends_on:
+      aerospike:
+        condition: service_healthy
+    environment:
+      AEROSPIKE_HOST: aerospike
+      AEROSPIKE_PORT: "3000"
+      LISTEN_PORT: "8090"
+    ports:
+      - "8090:8090"
+    networks:
+      - keploy-network
+
+networks:
+  keploy-network:

--- a/spring-aerospike/keploy.yml
+++ b/spring-aerospike/keploy.yml
@@ -1,0 +1,51 @@
+path: ""
+appId: 0
+appName: spring-aerospike
+command: java -jar target/spring-aerospike.jar
+templatize:
+    testSets: []
+port: 0
+dnsPort: 26789
+proxyPort: 16789
+incomingProxyPort: 36789
+debug: false
+disableTele: false
+disableANSI: false
+containerName: ""
+networkName: ""
+buildDelay: 30
+test:
+    selectedTests: {}
+    globalNoise:
+        global: {}
+        test-sets: {}
+    delay: 15
+    apiTimeout: 5
+    skipCoverage: false
+    coverageReportPath: ""
+    ignoreOrdering: true
+    mongoPassword: default@123
+    language: ""
+    removeUnusedMocks: false
+    fallBackOnMiss: false
+    jacocoAgentPath: ""
+    basePath: ""
+    mocking: true
+    ignoredTests: {}
+    strictMockWindow: true
+record:
+    filters: []
+    basePath: ""
+    recordTimer: 0s
+    metadata: ""
+    testCaseNaming: descriptive
+report:
+    selectedTestSets: {}
+    showFullBody: false
+    reportPath: ""
+    summary: false
+    testCaseIDs: []
+    format: ""
+keployContainer: keploy-v3
+keployNetwork: keploy-network
+cmdType: native

--- a/spring-aerospike/pom.xml
+++ b/spring-aerospike/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.7.18</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-aerospike</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>spring-aerospike</name>
+    <description>Aerospike-Java sample for Keploy record/replay</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.aerospike</groupId>
+            <artifactId>aerospike-client-jdk8</artifactId>
+            <version>9.0.5</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>spring-aerospike</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring-aerospike/scripts/common.sh
+++ b/spring-aerospike/scripts/common.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Shared helpers for scripts/script-*.sh.
+#
+# Each script-N.sh sources this file and then calls:
+#   run_test_set <target-test-set>  <curl-fn>
+# where <curl-fn> is a shell function that fires the HTTP requests
+# the test-set should capture.
+#
+# Layered behaviour:
+#   - Boots Aerospike CE via docker compose if not already up.
+#   - Builds the Spring Boot JAR.
+#   - Starts `keploy record` in the background; waits for the app to
+#     answer /health before firing the curls.
+#   - SIGINTs keploy when curls are done.
+#   - Normalises the recorded test-set path to ./keploy/<target>.
+#   - Adds `body.duration: []` to noise on any /parallel, /multiclient
+#     or /freshclient test (their responses carry wall-clock duration
+#     that drifts every run).
+#   - Replays the test-set and exits non-zero if any case fails.
+
+set -euo pipefail
+
+: "${KEPLOY:=sudo keploy}"
+: "${PORT:=8090}"
+: "${LOG_DIR:=/tmp}"
+: "${SKIP_DOCKER:=}"
+: "${SKIP_BUILD:=}"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+bring_up_aerospike() {
+    [ -n "${SKIP_DOCKER:-}" ] && return 0
+    echo "==> docker compose up -d aerospike"
+    docker compose up -d aerospike
+    for _ in $(seq 1 30); do
+        if docker compose ps aerospike --format '{{.Health}}' 2>/dev/null | grep -q healthy; then
+            return 0
+        fi
+        sleep 2
+    done
+    echo "ERROR: aerospike never reported healthy" >&2
+    docker compose logs aerospike | tail -30 >&2
+    return 1
+}
+
+build_app() {
+    [ -n "${SKIP_BUILD:-}" ] && return 0
+    echo "==> mvn -q -DskipTests package"
+    mvn -q -DskipTests package
+}
+
+wait_for_app_ready() {
+    echo "==> waiting for the sample to answer on :$PORT"
+    for _ in $(seq 1 120); do
+        if curl -sf -o /dev/null --max-time 1 "http://127.0.0.1:$PORT/health"; then
+            sleep 3
+            return 0
+        fi
+        sleep 1
+    done
+    echo "ERROR: app never answered /health" >&2
+    return 1
+}
+
+stop_keploy() {
+    sudo pkill -SIGINT keploy 2>/dev/null || true
+    for _ in $(seq 1 15); do
+        if ! pgrep -af "keploy record" >/dev/null 2>&1; then return 0; fi
+        sleep 1
+    done
+    echo "WARN: keploy didn't exit on SIGINT, killing"
+    sudo pkill -KILL keploy 2>/dev/null || true
+}
+
+# After record, keploy may have written ./keploy/keploy/test-set-N
+# (nested) instead of ./keploy/test-set-N (flat), and it auto-numbers
+# the fresh recording off whatever already exists under ./keploy/.
+# Normalise: flatten the nested case, then rename whichever fresh
+# test-set-* we got to the requested target.
+normalise_recording() {
+    local target="$1"
+    if [ -d "./keploy/keploy" ]; then
+        sudo chown -R "$(id -u):$(id -g)" ./keploy/keploy
+        for d in ./keploy/keploy/test-set-*; do
+            [ -d "$d" ] || continue
+            mv "$d" "./keploy/"
+        done
+        rmdir ./keploy/keploy 2>/dev/null || true
+    fi
+    [ -d "./keploy/$target" ] && return 0
+
+    local newest="" newest_mtime=0
+    for d in ./keploy/test-set-*; do
+        [ -d "$d" ] || continue
+        local m
+        m=$(stat -c %Y "$d")
+        if [ "$m" -gt "$newest_mtime" ]; then
+            newest="$d"; newest_mtime="$m"
+        fi
+    done
+    if [ -n "$newest" ]; then
+        mv "$newest" "./keploy/$target"
+        return 0
+    fi
+    echo "ERROR: $target was not recorded — check $LOG_DIR/keploy-record-$target.log" >&2
+    return 1
+}
+
+apply_duration_noise() {
+    local target="$1"
+    local applied=0
+    for f in ./keploy/"$target"/tests/post-parallel-*.yaml \
+             ./keploy/"$target"/tests/post-multiclient-*.yaml \
+             ./keploy/"$target"/tests/post-freshclient-*.yaml; do
+        [ -e "$f" ] || continue
+        if ! grep -q "body.duration:" "$f"; then
+            sed -i 's|header.Date: \[\]|header.Date: []\n      body.duration: []|' "$f"
+            applied=$((applied+1))
+        fi
+    done
+    [ "$applied" -gt 0 ] && echo "==> applied body.duration noise to $applied test(s)"
+    return 0
+}
+
+run_test_set() {
+    local target="$1"
+    local curl_fn="$2"
+
+    bring_up_aerospike
+    build_app
+
+    echo "==> clearing any stale ./keploy/$target"
+    sudo rm -rf "./keploy/$target"
+
+    local log="$LOG_DIR/keploy-record-$target.log"
+    echo "==> starting keploy record (logging to $log)"
+    $KEPLOY record > "$log" 2>&1 &
+    local keploy_pid=$!
+    trap 'stop_keploy' EXIT
+
+    wait_for_app_ready
+    echo "==> firing curls for $target"
+    $curl_fn
+    sleep 3
+
+    echo "==> stopping keploy record"
+    stop_keploy
+    trap - EXIT
+    wait "$keploy_pid" 2>/dev/null || true
+
+    normalise_recording "$target"
+    apply_duration_noise "$target"
+
+    echo "==> $KEPLOY test --test-sets $target"
+    $KEPLOY test --test-sets "$target"
+}

--- a/spring-aerospike/scripts/script-1.sh
+++ b/spring-aerospike/scripts/script-1.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# script-1.sh — record + replay test-set-0.
+#
+# Captures the single-endpoint CRUD coverage:
+#   GET /health  POST /put  GET /get  POST /batch/put  GET /batch/get
+#   POST /touch  DELETE /key
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+curls_test_set_0() {
+    curl -sf -o /dev/null "http://127.0.0.1:$PORT/health"
+    sleep 1
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/put" \
+        -H 'Content-Type: application/json' \
+        -d '{"key":"alice","bins":{"age":30,"name":"Alice"}}'
+    sleep 1
+    curl -sf -o /dev/null "http://127.0.0.1:$PORT/get/alice"
+    sleep 1
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/batch/put" \
+        -H 'Content-Type: application/json' \
+        -d '[{"key":"a","bins":{"n":1}},{"key":"b","bins":{"n":2}}]'
+    sleep 1
+    curl -s -o /dev/null "http://127.0.0.1:$PORT/batch/get?k=a&k=b" || true
+    sleep 1
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/touch/alice"
+    sleep 1
+    curl -sf -o /dev/null -XDELETE "http://127.0.0.1:$PORT/key/alice"
+}
+
+run_test_set test-set-0 curls_test_set_0

--- a/spring-aerospike/scripts/script-2.sh
+++ b/spring-aerospike/scripts/script-2.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# script-2.sh — record + replay test-set-1: /parallel n = 4..24.
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+curls_test_set_1() {
+    curl -sf -o /dev/null "http://127.0.0.1:$PORT/health"
+    sleep 1
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/parallel?n=4&prefix=run1"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/parallel?n=8&prefix=run2"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/parallel?n=12&prefix=run3"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/parallel?n=24&prefix=run4"
+}
+
+run_test_set test-set-1 curls_test_set_1

--- a/spring-aerospike/scripts/script-3.sh
+++ b/spring-aerospike/scripts/script-3.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# script-3.sh — record + replay test-set-2: /multiclient + /freshclient.
+
+set -euo pipefail
+source "$(dirname "$0")/common.sh"
+
+curls_test_set_2() {
+    curl -sf -o /dev/null "http://127.0.0.1:$PORT/health"
+    sleep 1
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/multiclient?n=4&prefix=mc1"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/multiclient?n=8&prefix=mc2"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/multiclient?n=12&prefix=mc3"
+    sleep 2
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/multiclient?n=24&prefix=mc4"
+    sleep 3
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/freshclient?n=4&prefix=fc1"
+    sleep 3
+    curl -sf -o /dev/null -XPOST "http://127.0.0.1:$PORT/freshclient?n=8&prefix=fc2"
+}
+
+run_test_set test-set-2 curls_test_set_2

--- a/spring-aerospike/src/main/java/com/example/aerospike/SpringAerospikeApplication.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/SpringAerospikeApplication.java
@@ -1,0 +1,11 @@
+package com.example.aerospike;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class SpringAerospikeApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(SpringAerospikeApplication.class, args);
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/config/AerospikeConfig.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/config/AerospikeConfig.java
@@ -1,0 +1,125 @@
+package com.example.aerospike.config;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Host;
+import com.aerospike.client.Key;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.Policy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds the main Aerospike client used by every controller, plus a small
+ * bank of 4 additional clients that {@code /multiclient} round-robins over.
+ *
+ * <p>Mirrors the Go sample's main.go: same pool sizing, same warmup
+ * shape — sequential prelude to walk the proxy past cold-start TLS,
+ * then a parallel fill to actually populate the pool so the first
+ * {@code /parallel} burst hits warm connections.
+ */
+@Configuration
+public class AerospikeConfig implements DisposableBean {
+
+    private static final Logger log = LoggerFactory.getLogger(AerospikeConfig.class);
+
+    private final AerospikeProperties props;
+    private AerospikeClient main;
+    private List<AerospikeClient> multi;
+
+    public AerospikeConfig(AerospikeProperties props) {
+        this.props = props;
+    }
+
+    public ClientPolicy buildClientPolicy() {
+        ClientPolicy policy = new ClientPolicy();
+        // Pin to seed: single-node CE setups don't have peers worth
+        // discovering and the discovery loop just adds noise.
+        policy.failIfNotConnected = true;
+        policy.connPoolsPerNode = 1;
+        policy.maxConnsPerNode = props.getConnectionQueueSize();
+        policy.asyncMaxConnsPerNode = props.getConnectionQueueSize();
+        // Hold concurrent-open low so a burst doesn't outpace stunnel /
+        // the proxy's TLS handshake rate. The Go sample uses the same
+        // 16 ceiling for the same reason.
+        policy.asyncMaxConnsPerNode = props.getOpeningConnectionThreshold();
+        return policy;
+    }
+
+    @Bean
+    public AerospikeClient aerospikeClient() {
+        ClientPolicy policy = buildClientPolicy();
+        Host host = new Host(props.getHost(), props.getPort());
+        main = new AerospikeClient(policy, host);
+        warmup(main, props.getWarmup().getSequential(), props.getWarmup().getParallel());
+        return main;
+    }
+
+    @Bean
+    public List<AerospikeClient> multiAerospikeClients() {
+        ClientPolicy policy = buildClientPolicy();
+        Host host = new Host(props.getHost(), props.getPort());
+        List<AerospikeClient> bank = new ArrayList<>(4);
+        for (int i = 0; i < 4; i++) {
+            bank.add(new AerospikeClient(policy, host));
+        }
+        multi = Collections.unmodifiableList(bank);
+        return multi;
+    }
+
+    /**
+     * Issues {@code seq} sequential Exists round-trips followed by
+     * {@code par} concurrent ones. The sequential leg walks the proxy
+     * past cold-start latency; the parallel leg actually puts {@code par}
+     * idle connections into the pool. Without phase 2, only a single
+     * connection ever sits in the pool because the Aerospike client
+     * returns a used connection to the next op's acquirer.
+     */
+    private void warmup(AerospikeClient client, int seq, int par) {
+        Policy pol = new Policy();
+        pol.socketTimeout = 10_000;
+        pol.totalTimeout = 30_000;
+        pol.maxRetries = 5;
+        pol.sleepBetweenRetries = 5;
+        try {
+            for (int i = 0; i < seq; i++) {
+                Key k = new Key(props.getNamespace(), props.getSet(), "warmup-seq-" + i);
+                client.exists(pol, k);
+            }
+            if (par > 0) {
+                Thread[] threads = new Thread[par];
+                for (int i = 0; i < par; i++) {
+                    final int idx = i;
+                    threads[i] = new Thread(() -> {
+                        try {
+                            Key k = new Key(props.getNamespace(), props.getSet(),
+                                    "warmup-par-" + idx);
+                            client.exists(pol, k);
+                        } catch (Throwable t) {
+                            // warmup is best-effort; the retry wrappers in /parallel
+                            // cover any pool slot that didn't make it.
+                        }
+                    });
+                    threads[i].start();
+                }
+                for (Thread t : threads) {
+                    t.join();
+                }
+            }
+        } catch (Throwable t) {
+            log.warn("warmup failed (non-fatal): {}", t.toString());
+        }
+    }
+
+    @Override
+    public void destroy() {
+        if (main != null) main.close();
+        if (multi != null) multi.forEach(AerospikeClient::close);
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/config/AerospikeProperties.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/config/AerospikeProperties.java
@@ -1,0 +1,40 @@
+package com.example.aerospike.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "aerospike")
+public class AerospikeProperties {
+    private String host = "127.0.0.1";
+    private int port = 3000;
+    private String namespace = "test";
+    private String set = "demo";
+    private int connectionQueueSize = 256;
+    private int openingConnectionThreshold = 16;
+    private Warmup warmup = new Warmup();
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+    public int getPort() { return port; }
+    public void setPort(int port) { this.port = port; }
+    public String getNamespace() { return namespace; }
+    public void setNamespace(String namespace) { this.namespace = namespace; }
+    public String getSet() { return set; }
+    public void setSet(String set) { this.set = set; }
+    public int getConnectionQueueSize() { return connectionQueueSize; }
+    public void setConnectionQueueSize(int v) { this.connectionQueueSize = v; }
+    public int getOpeningConnectionThreshold() { return openingConnectionThreshold; }
+    public void setOpeningConnectionThreshold(int v) { this.openingConnectionThreshold = v; }
+    public Warmup getWarmup() { return warmup; }
+    public void setWarmup(Warmup warmup) { this.warmup = warmup; }
+
+    public static class Warmup {
+        private int sequential = 8;
+        private int parallel = 32;
+        public int getSequential() { return sequential; }
+        public void setSequential(int v) { this.sequential = v; }
+        public int getParallel() { return parallel; }
+        public void setParallel(int v) { this.parallel = v; }
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/config/Policies.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/config/Policies.java
@@ -1,0 +1,33 @@
+package com.example.aerospike.config;
+
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.WritePolicy;
+
+/**
+ * Per-op policy helpers used by /parallel, /multiclient, /freshclient
+ * to ride out the cold-pool burst the Go sample's parallelWrite/Read
+ * policies were tuned for. Generous timeouts + retries + sleep gives
+ * the pool time to recycle connections across cooperative goroutine-
+ * equivalents (threads).
+ */
+public final class Policies {
+    private Policies() {}
+
+    public static WritePolicy parallelWrite() {
+        WritePolicy p = new WritePolicy();
+        p.socketTimeout = 10_000;
+        p.totalTimeout = 30_000;
+        p.maxRetries = 10;
+        p.sleepBetweenRetries = 5;
+        return p;
+    }
+
+    public static Policy parallelRead() {
+        Policy p = new Policy();
+        p.socketTimeout = 10_000;
+        p.totalTimeout = 30_000;
+        p.maxRetries = 10;
+        p.sleepBetweenRetries = 5;
+        return p;
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/AdvancedController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/AdvancedController.java
@@ -1,0 +1,82 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.Value;
+import com.aerospike.client.cdt.ListOperation;
+import com.aerospike.client.cdt.MapOperation;
+import com.aerospike.client.cdt.MapPolicy;
+import com.aerospike.client.query.Filter;
+import com.aerospike.client.query.RecordSet;
+import com.aerospike.client.query.Statement;
+import com.example.aerospike.config.AerospikeProperties;
+import com.example.aerospike.dto.PutRequest;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * The four extra endpoints that the Go sample carries — /scan,
+ * /query, /udf, /cdt/list/append, /cdt/map/put. The scripts don't
+ * exercise these, but ports of the Go sample include them for parity.
+ */
+@RestController
+public class AdvancedController {
+
+    private final AerospikeClient client;
+    private final AerospikeProperties props;
+
+    public AdvancedController(AerospikeClient client, AerospikeProperties props) {
+        this.client = client;
+        this.props = props;
+    }
+
+    @PostMapping("/scan")
+    public Map<String, Integer> scan() {
+        int[] count = {0};
+        client.scanAll(null, props.getNamespace(), props.getSet(), (key, record) -> count[0]++);
+        return Map.of("scanned", count[0]);
+    }
+
+    @PostMapping("/query")
+    public Map<String, Integer> query() {
+        Statement stmt = new Statement();
+        stmt.setNamespace(props.getNamespace());
+        stmt.setSetName(props.getSet());
+        stmt.setFilter(Filter.range("age", 0, 99));
+        int count = 0;
+        try (RecordSet rs = client.query(null, stmt)) {
+            while (rs.next()) {
+                count++;
+            }
+        }
+        return Map.of("matched", count);
+    }
+
+    @PostMapping("/udf")
+    public Map<String, Object> udf(@RequestBody PutRequest req) {
+        Key k = new Key(props.getNamespace(), props.getSet(), req.getKey());
+        Object out = client.execute(null, k, "transform", "apply", Value.get("bin"), Value.get(1));
+        return Map.of("result", out == null ? "null" : out.toString());
+    }
+
+    @PostMapping("/cdt/list/append")
+    public Map<String, String> cdtListAppend(@RequestBody PutRequest req) {
+        Key k = new Key(props.getNamespace(), props.getSet(), req.getKey());
+        Object v = req.getBins() == null ? null : req.getBins().get("value");
+        client.operate(null, k, ListOperation.append("items", Value.get(v)));
+        return Map.of("status", "appended");
+    }
+
+    @PostMapping("/cdt/map/put")
+    public Map<String, String> cdtMapPut(@RequestBody PutRequest req) {
+        Key k = new Key(props.getNamespace(), props.getSet(), req.getKey());
+        Map<String, Object> bins = req.getBins() == null ? new HashMap<>() : req.getBins();
+        Value mapKey = Value.get(bins.get("mapKey"));
+        Value mapVal = Value.get(bins.get("mapVal"));
+        client.operate(null, k, MapOperation.put(MapPolicy.Default, "mapBin", mapKey, mapVal));
+        return Map.of("status", "put");
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/CrudController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/CrudController.java
@@ -1,0 +1,95 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.AerospikeException;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.example.aerospike.config.AerospikeProperties;
+import com.example.aerospike.dto.PutRequest;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+public class CrudController {
+
+    private final AerospikeClient client;
+    private final AerospikeProperties props;
+
+    public CrudController(AerospikeClient client, AerospikeProperties props) {
+        this.client = client;
+        this.props = props;
+    }
+
+    @PostMapping("/put")
+    public Map<String, String> put(@RequestBody PutRequest req) {
+        Key k = new Key(props.getNamespace(), props.getSet(), req.getKey());
+        Bin[] bins = toBins(req.getBins());
+        client.put(null, k, bins);
+        return Map.of("status", "ok");
+    }
+
+    @GetMapping("/get/{key}")
+    public Map<String, Object> get(@PathVariable("key") String key) {
+        Key k = new Key(props.getNamespace(), props.getSet(), key);
+        Record rec = client.get(null, k);
+        if (rec == null) {
+            throw new AerospikeException("record not found: " + key);
+        }
+        return rec.bins;
+    }
+
+    @PostMapping("/batch/put")
+    public Map<String, Integer> batchPut(@RequestBody List<PutRequest> body) {
+        for (PutRequest p : body) {
+            Key k = new Key(props.getNamespace(), props.getSet(), p.getKey());
+            client.put(null, k, toBins(p.getBins()));
+        }
+        return Map.of("written", body.size());
+    }
+
+    @GetMapping("/batch/get")
+    public List<Map<String, Object>> batchGet(@RequestParam("k") List<String> keys) {
+        Key[] batch = new Key[keys.size()];
+        for (int i = 0; i < keys.size(); i++) {
+            batch[i] = new Key(props.getNamespace(), props.getSet(), keys.get(i));
+        }
+        Record[] records = client.get(null, batch);
+        List<Map<String, Object>> out = new ArrayList<>(records.length);
+        for (Record r : records) {
+            out.add(r == null ? null : r.bins);
+        }
+        return out;
+    }
+
+    private static Bin[] toBins(Map<String, Object> bins) {
+        if (bins == null) return new Bin[0];
+        Bin[] out = new Bin[bins.size()];
+        int i = 0;
+        for (Map.Entry<String, Object> e : bins.entrySet()) {
+            out[i++] = toBin(e.getKey(), e.getValue());
+        }
+        return out;
+    }
+
+    /**
+     * Coerce JSON-decoded values into Aerospike Bin values. The
+     * Aerospike Java client's Bin constructor is overloaded but
+     * doesn't accept {@code Number} — pick the concrete numeric type
+     * Jackson handed us (Integer / Long / Double) and unwrap.
+     */
+    static Bin toBin(String name, Object value) {
+        if (value instanceof Integer) return new Bin(name, (Integer) value);
+        if (value instanceof Long) return new Bin(name, (Long) value);
+        if (value instanceof Double) return new Bin(name, (Double) value);
+        if (value instanceof Float) return new Bin(name, (Float) value);
+        if (value instanceof Boolean) return new Bin(name, ((Boolean) value) ? 1 : 0);
+        if (value instanceof List) return new Bin(name, (List<?>) value);
+        if (value instanceof Map) return new Bin(name, (Map<?, ?>) value);
+        return new Bin(name, value == null ? null : value.toString());
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/FreshClientController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/FreshClientController.java
@@ -1,0 +1,101 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Host;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.ClientPolicy;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.WritePolicy;
+import com.example.aerospike.config.AerospikeConfig;
+import com.example.aerospike.config.AerospikeProperties;
+import com.example.aerospike.config.Policies;
+import com.example.aerospike.util.RetryHelper;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+@RestController
+public class FreshClientController {
+
+    private final AerospikeConfig config;
+    private final AerospikeProperties props;
+    private final WritePolicy wp = Policies.parallelWrite();
+    private final Policy rp = Policies.parallelRead();
+    private final Semaphore concurrencyCap = new Semaphore(4);
+
+    public FreshClientController(AerospikeConfig config, AerospikeProperties props) {
+        this.config = config;
+        this.props = props;
+    }
+
+    @PostMapping("/freshclient")
+    public Map<String, Object> freshClient(@RequestParam(value = "n", defaultValue = "4") int n,
+                                           @RequestParam(value = "prefix", defaultValue = "fc") String prefix) {
+        if (n <= 0) n = 4;
+        if (n > 16) n = 16;
+
+        ClientPolicy cp = config.buildClientPolicy();
+        Host host = new Host(props.getHost(), props.getPort());
+
+        ExecutorService pool = Executors.newFixedThreadPool(n);
+        Map<String, Object>[] out = new Map[n];
+        CountDownLatch done = new CountDownLatch(n);
+        long start = System.nanoTime();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            pool.submit(() -> {
+                try {
+                    concurrencyCap.acquire();
+                    try {
+                        String key = prefix + "-" + idx;
+                        try (AerospikeClient c = new AerospikeClient(cp, host)) {
+                            Key k = new Key(props.getNamespace(), props.getSet(), key);
+                            Bin[] bins = { new Bin("idx", idx), new Bin("tag", prefix) };
+                            try {
+                                RetryHelper.doOp(5, 10, () -> c.put(wp, k, bins));
+                            } catch (Exception e) {
+                                out[idx] = Map.of("key", key, "error", "put: " + e.getMessage());
+                                return;
+                            }
+                            Record[] recRef = new Record[1];
+                            try {
+                                RetryHelper.doOp(5, 10, () -> recRef[0] = c.get(rp, k));
+                            } catch (Exception e) {
+                                out[idx] = Map.of("key", key, "error", "get: " + e.getMessage());
+                                return;
+                            }
+                            out[idx] = recRef[0] == null
+                                    ? Map.of("key", key, "error", "get: record not found")
+                                    : Map.of("key", key, "bins", recRef[0].bins);
+                        } catch (Exception e) {
+                            out[idx] = Map.of("key", key, "error", "newclient: " + e.getMessage());
+                        }
+                    } finally {
+                        concurrencyCap.release();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        try {
+            done.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        pool.shutdown();
+        long durNanos = System.nanoTime() - start;
+        return Map.of(
+                "workers", n,
+                "prefix", prefix,
+                "concurrency", 4,
+                "duration", String.format("%.6fms", durNanos / 1_000_000.0),
+                "results", Arrays.asList(out)
+        );
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/HealthController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/HealthController.java
@@ -1,0 +1,26 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.cluster.Node;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+public class HealthController {
+    private final AerospikeClient client;
+
+    public HealthController(AerospikeClient client) {
+        this.client = client;
+    }
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        Node[] nodes = client.getNodes();
+        return Map.of(
+                "nodes", nodes.length,
+                "namespaces", "test"
+        );
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/MaintenanceController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/MaintenanceController.java
@@ -1,0 +1,34 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Key;
+import com.example.aerospike.config.AerospikeProperties;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+public class MaintenanceController {
+
+    private final AerospikeClient client;
+    private final AerospikeProperties props;
+
+    public MaintenanceController(AerospikeClient client, AerospikeProperties props) {
+        this.client = client;
+        this.props = props;
+    }
+
+    @PostMapping("/touch/{key}")
+    public Map<String, String> touch(@PathVariable("key") String key) {
+        Key k = new Key(props.getNamespace(), props.getSet(), key);
+        client.touch(null, k);
+        return Map.of("status", "touched");
+    }
+
+    @DeleteMapping("/key/{key}")
+    public Map<String, Boolean> delete(@PathVariable("key") String key) {
+        Key k = new Key(props.getNamespace(), props.getSet(), key);
+        boolean deleted = client.delete(null, k);
+        return Map.of("deleted", deleted);
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/MultiClientController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/MultiClientController.java
@@ -1,0 +1,88 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.WritePolicy;
+import com.example.aerospike.config.AerospikeProperties;
+import com.example.aerospike.config.Policies;
+import com.example.aerospike.util.RetryHelper;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+@RestController
+public class MultiClientController {
+
+    private final List<AerospikeClient> clients;
+    private final AerospikeProperties props;
+    private final WritePolicy wp = Policies.parallelWrite();
+    private final Policy rp = Policies.parallelRead();
+
+    public MultiClientController(List<AerospikeClient> multiAerospikeClients,
+                                 AerospikeProperties props) {
+        this.clients = multiAerospikeClients;
+        this.props = props;
+    }
+
+    @PostMapping("/multiclient")
+    public Map<String, Object> multiClient(@RequestParam(value = "n", defaultValue = "8") int n,
+                                           @RequestParam(value = "prefix", defaultValue = "mc") String prefix) {
+        if (clients.isEmpty()) {
+            throw new IllegalStateException("no multi-clients configured");
+        }
+        if (n <= 0) n = 8;
+        if (n > 128) n = 128;
+
+        ExecutorService pool = Executors.newFixedThreadPool(n);
+        Map<String, Object>[] out = new Map[n];
+        CountDownLatch done = new CountDownLatch(n);
+        long start = System.nanoTime();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            final AerospikeClient c = clients.get(i % clients.size());
+            pool.submit(() -> {
+                try {
+                    String key = prefix + "-" + idx;
+                    Key k = new Key(props.getNamespace(), props.getSet(), key);
+                    Bin[] bins = { new Bin("idx", idx), new Bin("tag", prefix) };
+                    try {
+                        RetryHelper.doOp(5, 10, () -> c.put(wp, k, bins));
+                    } catch (Exception e) {
+                        out[idx] = Map.of("key", key, "error", "put: " + e.getMessage());
+                        return;
+                    }
+                    Record[] recRef = new Record[1];
+                    try {
+                        RetryHelper.doOp(5, 10, () -> recRef[0] = c.get(rp, k));
+                    } catch (Exception e) {
+                        out[idx] = Map.of("key", key, "error", "get: " + e.getMessage());
+                        return;
+                    }
+                    out[idx] = recRef[0] == null
+                            ? Map.of("key", key, "error", "get: record not found")
+                            : Map.of("key", key, "bins", recRef[0].bins);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        try {
+            done.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        pool.shutdown();
+        long durNanos = System.nanoTime() - start;
+        return Map.of(
+                "workers", n,
+                "prefix", prefix,
+                "clients", clients.size(),
+                "duration", String.format("%.6fms", durNanos / 1_000_000.0),
+                "results", Arrays.asList(out)
+        );
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/controller/ParallelController.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/controller/ParallelController.java
@@ -1,0 +1,88 @@
+package com.example.aerospike.controller;
+
+import com.aerospike.client.AerospikeClient;
+import com.aerospike.client.Bin;
+import com.aerospike.client.Key;
+import com.aerospike.client.Record;
+import com.aerospike.client.policy.Policy;
+import com.aerospike.client.policy.WritePolicy;
+import com.example.aerospike.config.AerospikeProperties;
+import com.example.aerospike.config.Policies;
+import com.example.aerospike.util.RetryHelper;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+@RestController
+public class ParallelController {
+
+    private final AerospikeClient client;
+    private final AerospikeProperties props;
+    private final WritePolicy wp = Policies.parallelWrite();
+    private final Policy rp = Policies.parallelRead();
+
+    public ParallelController(AerospikeClient client, AerospikeProperties props) {
+        this.client = client;
+        this.props = props;
+    }
+
+    @PostMapping("/parallel")
+    public Map<String, Object> parallel(@RequestParam(value = "n", defaultValue = "8") int n,
+                                        @RequestParam(value = "prefix", defaultValue = "p") String prefix) {
+        if (n <= 0) n = 8;
+        if (n > 128) n = 128;
+        return runBurst(n, prefix, client);
+    }
+
+    Map<String, Object> runBurst(int n, String prefix, AerospikeClient client) {
+        ExecutorService pool = Executors.newFixedThreadPool(n);
+        Map<String, Object>[] out = new Map[n];
+        CountDownLatch done = new CountDownLatch(n);
+        long start = System.nanoTime();
+        for (int i = 0; i < n; i++) {
+            final int idx = i;
+            pool.submit(() -> {
+                try {
+                    String key = prefix + "-" + idx;
+                    Key k = new Key(props.getNamespace(), props.getSet(), key);
+                    Bin[] bins = new Bin[] {
+                            new Bin("idx", idx),
+                            new Bin("tag", prefix),
+                    };
+                    try {
+                        RetryHelper.doOp(5, 10, () -> client.put(wp, k, bins));
+                    } catch (Exception e) {
+                        out[idx] = Map.of("key", key, "error", "put: " + e.getMessage());
+                        return;
+                    }
+                    Record[] recRef = new Record[1];
+                    try {
+                        RetryHelper.doOp(5, 10, () -> recRef[0] = client.get(rp, k));
+                    } catch (Exception e) {
+                        out[idx] = Map.of("key", key, "error", "get: " + e.getMessage());
+                        return;
+                    }
+                    out[idx] = recRef[0] == null
+                            ? Map.of("key", key, "error", "get: record not found")
+                            : Map.of("key", key, "bins", recRef[0].bins);
+                } finally {
+                    done.countDown();
+                }
+            });
+        }
+        try {
+            done.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        pool.shutdown();
+        long durNanos = System.nanoTime() - start;
+        return Map.of(
+                "workers", n,
+                "prefix", prefix,
+                "duration", String.format("%.6fms", durNanos / 1_000_000.0),
+                "results", Arrays.asList(out)
+        );
+    }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/dto/PutRequest.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/dto/PutRequest.java
@@ -1,0 +1,13 @@
+package com.example.aerospike.dto;
+
+import java.util.Map;
+
+public class PutRequest {
+    private String key;
+    private Map<String, Object> bins;
+
+    public String getKey() { return key; }
+    public void setKey(String key) { this.key = key; }
+    public Map<String, Object> getBins() { return bins; }
+    public void setBins(Map<String, Object> bins) { this.bins = bins; }
+}

--- a/spring-aerospike/src/main/java/com/example/aerospike/util/RetryHelper.java
+++ b/spring-aerospike/src/main/java/com/example/aerospike/util/RetryHelper.java
@@ -1,0 +1,39 @@
+package com.example.aerospike.util;
+
+/**
+ * App-level retry wrapper for /parallel, /multiclient, /freshclient.
+ * Mirrors the Go sample's parallelDo: attempts the operation up to
+ * {@code attempts} times with {@code backoffMs} between attempts.
+ * The Aerospike client's MaxRetries handles per-op connection retries,
+ * but this outer loop gives the pool more time to recycle connections
+ * returned by cooperative threads in the same burst.
+ */
+public final class RetryHelper {
+    private RetryHelper() {}
+
+    @FunctionalInterface
+    public interface ThrowingOp {
+        void run() throws Exception;
+    }
+
+    public static void doOp(int attempts, int backoffMs, ThrowingOp op) throws Exception {
+        Exception last = null;
+        for (int i = 0; i < attempts; i++) {
+            try {
+                op.run();
+                return;
+            } catch (Exception e) {
+                last = e;
+                if (backoffMs > 0) {
+                    try {
+                        Thread.sleep(backoffMs);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw ie;
+                    }
+                }
+            }
+        }
+        throw last;
+    }
+}

--- a/spring-aerospike/src/main/resources/application.properties
+++ b/spring-aerospike/src/main/resources/application.properties
@@ -1,0 +1,14 @@
+server.port=${LISTEN_PORT:8090}
+
+aerospike.host=${AEROSPIKE_HOST:127.0.0.1}
+aerospike.port=${AEROSPIKE_PORT:3000}
+aerospike.namespace=test
+aerospike.set=demo
+aerospike.connection-queue-size=256
+aerospike.opening-connection-threshold=16
+aerospike.warmup.sequential=8
+aerospike.warmup.parallel=32
+
+# Quiet down Spring's banner noise; keploy log capture parses well-formed lines.
+spring.main.banner-mode=off
+logging.level.root=INFO


### PR DESCRIPTION
## Summary
- New `spring-aerospike/` sample — Spring Boot 2.7 + `aerospike-client-jdk8`, talks to Aerospike CE on clear-text 3000.
- Java counterpart of [`keploy/samples-go/aerospike-tls`](https://github.com/keploy/samples-go/tree/add-aerospike-tls-sample/aerospike-tls). Endpoints and concurrency knobs are a one-to-one port (14 endpoints, two-phase warmup, generous per-op policy, app-level retry wrapper).
- Three pipeline-ready scripts (`scripts/script-{1,2,3}.sh`) that record + replay one test-set each: CRUD, `/parallel`, `/multiclient` + `/freshclient`.
- No bundled `keploy/` — every script regenerates the test-set, so every CI run validates the full record→replay loop.

Depends on the Aerospike parser landing in keploy: keploy/keploy#4190 + keploy/integrations#194.

## Test plan
- [x] `mvn -q -DskipTests package` clean
- [x] `docker compose up -d aerospike` healthy
- [x] `./scripts/script-1.sh` → test-set-0: **8/8 pass**
- [x] `./scripts/script-2.sh` → test-set-1: **6/6 pass** (`/parallel?n=24` included)
- [x] `./scripts/script-3.sh` → test-set-2: **8/8 pass** (`/multiclient?n=24` + `/freshclient?n=8`)

All three scripts validated locally with the dev keploy binary carrying the Aerospike parser before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)