### PR TITLE
feat(spring-mysql-redis): add endpoint to trigger COM_STMT_RESET

### DIFF
--- a/spring-mysql-redis/src/main/java/org/example/todo/controller/TodoController.java
+++ b/spring-mysql-redis/src/main/java/org/example/todo/controller/TodoController.java
@@ -6,7 +6,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
@@ -15,6 +23,9 @@ public class TodoController {
 
     @Autowired
     private TodoService todoService;
+
+    @Autowired
+    private DataSource dataSource;
 
     @GetMapping
     public List<Todo> getAllTodos() {
@@ -51,5 +62,49 @@ public class TodoController {
     public ResponseEntity<Void> deleteTodo(@PathVariable Long id) {
         todoService.deleteById(id);
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Re-executes a server-side prepared statement {@code n} times on the same
+     * connection. With {@code useServerPrepStmts=true} and
+     * {@code useCursorFetch=true} (set in application.properties) plus a
+     * non-zero fetchSize, MySQL Connector/J 8.x sends a COM_STMT_RESET packet
+     * between re-executions to clear the cursor state. This endpoint exists to
+     * exercise that code path so Keploy record/replay can capture and match
+     * COM_STMT_RESET frames.
+     */
+    @GetMapping("/stmt-reset/{id}/{n}")
+    public ResponseEntity<Map<String, Object>> stmtReset(@PathVariable Long id,
+                                                         @PathVariable int n) throws SQLException {
+        List<Map<String, Object>> rows = new ArrayList<>();
+        String sql = "SELECT id, title, description, completed FROM todo WHERE id = ?";
+
+        try (Connection conn = dataSource.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+
+            // Forces server-side cursor (with useCursorFetch=true), which is
+            // what causes Connector/J to emit COM_STMT_RESET on re-execution.
+            ps.setFetchSize(1);
+
+            for (int i = 0; i < n; i++) {
+                ps.setLong(1, id);
+                try (ResultSet rs = ps.executeQuery()) {
+                    if (rs.next()) {
+                        Map<String, Object> row = new HashMap<>();
+                        row.put("id", rs.getLong("id"));
+                        row.put("title", rs.getString("title"));
+                        row.put("description", rs.getString("description"));
+                        row.put("completed", rs.getBoolean("completed"));
+                        rows.add(row);
+                    }
+                }
+            }
+        }
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("iterations", n);
+        response.put("rowsFetched", rows.size());
+        response.put("results", rows);
+        return ResponseEntity.ok(response);
     }
 }

--- a/spring-mysql-redis/src/main/resources/application.properties
+++ b/spring-mysql-redis/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # MySQL Configuration
-spring.datasource.url=jdbc:mysql://localhost:3306/todoapp?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
+spring.datasource.url=jdbc:mysql://localhost:3306/todoapp?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true&useServerPrepStmts=true&cachePrepStmts=true&useCursorFetch=true
 spring.datasource.username=yourusername
 spring.datasource.password=yourpassword
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## Summary
- Adds `GET /api/todos/stmt-reset/{id}/{n}` to `spring-mysql-redis` that re-executes a server-side prepared statement `n` times on the same connection.
- Updates the JDBC URL with `useServerPrepStmts=true&cachePrepStmts=true&useCursorFetch=true` so MySQL Connector/J 8.x emits `COM_STMT_RESET` between re-executions.
- Lets us exercise the synthetic-OK fallback path added in keploy/keploy#4217 during keploy record/replay.

## Why
keploy/keploy#4217 fixes the case where an unmocked `COM_STMT_RESET` would cause keploy to close the TCP connection, surfacing as `CJCommunicationsException` / `Socket is closed`. None of the existing sample endpoints reliably trigger `COM_STMT_RESET`, so we need a dedicated path that forces server-side cursor reuse.

## How to test
```bash
cd spring-mysql-redis
docker run --name mysql-todo -e MYSQL_DATABASE=todoapp \
  -e MYSQL_USER=yourusername -e MYSQL_PASSWORD=yourpassword \
  -e MYSQL_ROOT_PASSWORD=rootpassword -p 3306:3306 -d mysql:8
mvn -DskipTests package

# record (local keploy build with PR #4217)
keploy record -c "java -jar target/todo-spring-app-1.0-SNAPSHOT.jar"

# in another shell
curl -X POST http://localhost:8080/api/todos -H 'Content-Type: application/json' \
  -d '{"title":"t1","description":"d1","completed":false}'
curl http://localhost:8080/api/todos/stmt-reset/1/5

# replay
keploy test -c "java -jar target/todo-spring-app-1.0-SNAPSHOT.jar" --delay 20
```

## Test plan
- [ ] `mvn package` succeeds (note: pre-existing Lombok/`@Data` config in `pom.xml` may need annotation-processor wiring on Java 21 — unrelated to this PR).
- [ ] `keploy record` against the endpoint captures the new traffic.
- [ ] `keploy test` replay logs show the `COM_STMT_RESET` debug line (stmt id) from keploy/keploy#4217.
- [ ] Replay completes without `CJCommunicationsException` / `SQLSTATE 08S01` / `Socket is closed` in the app logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)