### PR TITLE
fix(tidb-stmt-cache): use TiDB built-in defaults, drop bogus command flags

### DIFF
--- a/tidb-stmt-cache/docker-compose.yml
+++ b/tidb-stmt-cache/docker-compose.yml
@@ -1,14 +1,12 @@
-version: '3.8'
-
 # Minimal single-node TiDB for keploy e2e.
 #
 # Why this stack and not the full pingcap/tidb-docker-compose with PD + TiKV?
 # - The sample only exercises the SQL layer (MySQL wire protocol on :4000).
 #   Coordination / storage flakiness in a 3-container topology adds CI noise
 #   without buying us any matcher coverage.
-# - `--store=unistore` keeps everything in a single process backed by an
-#   in-memory storage engine. Boot time is ~5s vs ~30-45s for a full PD+TiKV
-#   stack. Data is volatile, which is exactly what we want for keploy CI.
+# - The default `pingcap/tidb` entrypoint already runs in unistore (single
+#   process, in-memory) mode when no PD address is supplied, which is exactly
+#   what we want for keploy CI: ~5s boot, volatile data, no extra containers.
 #
 # Pin: v8.5.x is the LTS line current at the time this sample was added.
 # Bump as new LTS lines ship; the matcher behaviour we're testing has been
@@ -16,17 +14,6 @@ version: '3.8'
 services:
   tidb:
     image: pingcap/tidb:v8.5.6
-    command:
-      - --store=unistore
-      - --path=""
-      - --host=0.0.0.0
-      - --advertise-address=tidb
-      - --log-level=error
     ports:
       - "4000:4000"   # MySQL wire protocol
       - "10080:10080" # status / readiness
-    healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:10080/status || exit 1"]
-      interval: 2s
-      timeout: 2s
-      retries: 30


### PR DESCRIPTION
## Summary

Follow-up to #137. The TiDB compose file shipped with the new
`tidb-stmt-cache` sample passed double-dash flags
(`--store=unistore`, `--log-level=error`, ...) to the `pingcap/tidb`
entrypoint. TiDB uses single-dash flags, so the container exited at
startup with:

```
flag provided but not defined: -log-level
```

This broke the keploy-side `tidb_stmt_cache` CI job, which never
reaches `:4000`.

Fix: drop the entire `command:` block. The default entrypoint already
runs in unistore (single-process, in-memory) mode when no PD address
is supplied, which is what this sample needs. Also drop the obsolete
`version:` key and the wget-based healthcheck (wget is not in the
slim TiDB image; the keploy CI script polls `:10080/status` itself
before driving traffic).

## Test plan

- [x] `docker compose -f tidb-stmt-cache/docker-compose.yml up -d` boots
      TiDB cleanly and `:4000` accepts MySQL connections
- [ ] keploy CI `tidb_stmt_cache` matrix turns green once this lands
      and the keploy fix branch re-runs against `samples-java/main`