### PR TITLE
chore: replace the temp slack url to permanent route

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in Keploy and for taking the time to contribute to this project. 🙌
 Keploy is a project by developers for developers and there are a lot of ways you can contribute.
-If you don't know where to start contributing, ask us on our [Slack channel](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA).
+If you don't know where to start contributing, ask us on our [Slack channel](https://keploy.io/slack).
 
 ## Code of conduct
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <a href="CODE_OF_CONDUCT.md" alt="Contributions welcome">
     <img src="https://img.shields.io/badge/Contributions-Welcome-brightgreen?logo=github" /></a>
     
-  <a href="https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA" alt="Slack">
+  <a href="https://keploy.io/slack" alt="Slack">
     <img src="https://github.com/keploy/samples-go/blob/main/.github/slack.svg?raw=true" /></a>
     
   <a href="https://opensource.org/licenses/Apache-2.0" alt="License">
@@ -33,7 +33,7 @@ This repo contains the sample for [Keploy's](https://keploy.io) Java Application
 
 Reach out to us. We're here to help!
 
-[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+[![Slack](https://img.shields.io/badge/Slack-4A154B?style=for-the-badge&logo=slack&logoColor=white)](https://keploy.io/slack)
 [![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/keploy/)
 [![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/channel/UC6OTg7F4o0WkmNtSoob34lg)
 [![Twitter](https://img.shields.io/badge/Twitter-%231DA1F2.svg?style=for-the-badge&logo=Twitter&logoColor=white)](https://twitter.com/Keployio)

--- a/spring-petclinic/README.md
+++ b/spring-petclinic/README.md
@@ -107,4 +107,4 @@ keploy test -c "docker compose up" --containerName javaApp --buildDelay 50s --de
 Here `delay` is the time it takes for your application to get started, after which Keploy will start running the testcases. If your application takes longer than 10s to get started, you can change the `delay` accordingly.
 `buildDelay` is the time that it takes for the image to get built. This is useful when you are building the docker image from your docker compose file itself.
 
-Hope this helps you out, if you still have any questions, reach out to us on our [Slack](https://join.slack.com/t/keploy/shared_invite/zt-3zcnuqfgl-WYK1NMhslVHsCtNcA1ULwA)
+Hope this helps you out, if you still have any questions, reach out to us on our [Slack](https://keploy.io/slack)


### PR DESCRIPTION
This PR replaces the temporary, hardcoded Slack invite links across the repository with the permanent redirect route (https://keploy.io/slack). This ensures that users are always directed to the active community workspace and avoids invite link expiration issues.

## Files Modified

* CONTRIBUTING.md - Updated the main channel invite link.
* README.md - Updated the header badge and logo links in the community support section.
* spring-petclinic/README.md - Updated the Slack help link in the project documentation.

## Checklist

* [x] Verified all occurrences of the old Slack invite link (join.slack.com) were replaced.
* [x] Prepared the commit with DCO sign-off (-s) as per repository rules.