### PR TITLE
feat(tidb-stmt-cache): add /api/cross orphaned same-param-shape endpoint

### DIFF
--- a/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/QueryController.java
+++ b/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/QueryController.java
@@ -86,4 +86,24 @@ public class QueryController {
         out.put("readback", last);
         return out;
     }
+
+    /**
+     * Two distinct prepared queries with an IDENTICAL parameter signature
+     * (one int) issued in the SAME request — exercises the orphaned-EXECUTE
+     * cross-query matcher path.
+     *
+     * When both PREPAREs predate the record window (orphaned mocks,
+     * expectedQuery==""), a param-only match must NOT serve query B's row for
+     * query A just because the bound parameter is equal. {@code a} must echo v
+     * and {@code b} must be v+1000.
+     */
+    @GetMapping("/api/cross/{v}")
+    public Map<String, Object> cross(@PathVariable("v") int v) {
+        Integer a = jdbc.queryForObject("SELECT ? AS v", Integer.class, v);
+        Integer b = jdbc.queryForObject("SELECT ? + 1000 AS w", Integer.class, v);
+        Map<String, Object> out = new HashMap<>();
+        out.put("a", a);
+        out.put("b", b);
+        return out;
+    }
 }


### PR DESCRIPTION
## Describe the changes that are made

Adds `GET /api/cross/{v}` to the `tidb-stmt-cache` sample: it issues two
**distinct** prepared queries with an identical one-int parameter signature in
a single request (`SELECT ? AS v` and `SELECT ? + 1000 AS w`). When both
PREPAREs predate keploy's record window (orphaned mocks), this exercises the
parameter-aware orphaned-EXECUTE path — a param-only match must not serve query
B's row for query A. `a` must echo `v`, `b` must be `v+1000`.

Consumed by the keploy/keploy `java_linux` `tidb-stmt-cache` e2e job.

## What type of PR is this?
- [x] ✅ Test (sample-app endpoint for e2e coverage)

```
curl localhost:8080/api/cross/7   # -> {"a":7,"b":1007}
```

> In-repo replacement for #143 (which was from a fork). Branch moved here so CI runs without the fork guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)