### PR TITLE
async-config-poll: add httpPoll (long-poll) scenario

### DIFF
--- a/async-config-poll/config-stub/main.go
+++ b/async-config-poll/config-stub/main.go
@@ -5,6 +5,11 @@
 //   - GET /v1/buckets/app-config?watch=true&version=N -> long-poll: returns the
 //     NEXT version (N+1), simulating a config change on each watch poll.
 //
+// By default a watch poll returns immediately (the periodic-poller scenario).
+// Set POLL_HOLD_SECONDS>0 to model a real long-poll with a server timeout: the
+// watch=true request is HELD open that long before delivering the next version
+// (the httpPoll scenario), so Keploy records its open-duration as pollDurationMs.
+//
 // It is hit only during `keploy record`. At replay time Keploy serves the
 // recorded responses instead, so this stub does not need to be running.
 package main
@@ -13,11 +18,26 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
+// pollHold is the long-poll server timeout: a watch=true request is held open
+// this long before delivering the next version. Default 0 (respond
+// immediately); override with POLL_HOLD_SECONDS.
+func pollHold() time.Duration {
+	if s := os.Getenv("POLL_HOLD_SECONDS"); s != "" {
+		if n, err := strconv.Atoi(s); err == nil {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 0
+}
+
 func main() {
+	hold := pollHold()
 	http.HandleFunc("/v1/buckets/", func(w http.ResponseWriter, r *http.Request) {
 		name := strings.TrimPrefix(r.URL.Path, "/v1/buckets/")
 		q := r.URL.Query()
@@ -25,6 +45,15 @@ func main() {
 		version := 1
 		if q.Get("watch") == "true" {
 			cur, _ := strconv.Atoi(q.Get("version"))
+			if hold > 0 {
+				// Long-poll: hold the connection open until the server timeout,
+				// then deliver the next version. Abort if the client disconnects.
+				select {
+				case <-time.After(hold):
+				case <-r.Context().Done():
+					return
+				}
+			}
 			version = cur + 1 // deliver the next version -> a "change" per poll
 		}
 

--- a/async-config-poll/keploy-httppoll.yml
+++ b/async-config-poll/keploy-httppoll.yml
@@ -1,0 +1,26 @@
+# Keploy config for the async-config-poll sample — httpPoll scenario.
+#
+# Identical to keploy.yml except the async lane's type is `httpPoll` instead of
+# `http`. `httpPoll` marks the config-watch egress as a long-poll: at record
+# Keploy stamps the mock kind `HttpPoll` and captures its open-duration
+# (pollDurationMs); at replay the async engine HOLDS the poll until its resolve
+# testcase and then serves it (verdict `held`), instead of serving it as soon as
+# the request arrives. Paired with POLL_HOLD_SECONDS on the config-stub and
+# WATCH_ONCE on the app so the recording holds a single server-timeout long-poll.
+#
+# Lane "config-watch":
+#   - match.pathRegex  : only the /v1/buckets/app-config endpoint
+#   - matchQuery.watch : "true"  -> only the background watch polls (the
+#                         one-time boot "get current version" call uses
+#                         watch=false and stays an ordinary blocking mock)
+#   - volatileParams   : ["version"] -> the version query param changes every
+#                         poll, so it is treated as shape-noise, not a mismatch
+async:
+    lanes:
+        - name: config-watch
+          type: httpPoll
+          match:
+              pathRegex: "^/v1/buckets/app-config$"
+          matchQuery:
+              watch: "true"
+          volatileParams: ["version"]

--- a/async-config-poll/src/main/java/com/example/asyncconfig/config/ConfigWatchService.java
+++ b/async-config-poll/src/main/java/com/example/asyncconfig/config/ConfigWatchService.java
@@ -63,6 +63,11 @@ public class ConfigWatchService {
     }
 
     private void startWatchPoller() {
+        // WATCH_ONCE opens exactly ONE watch poll then stops the daemon. The
+        // httpPoll scenario uses it so the whole recording holds a single long
+        // poll (a server-timeout long-poll) rather than a stream of them; the
+        // default (unset) keeps the periodic-poller behavior.
+        final boolean watchOnce = "true".equalsIgnoreCase(System.getenv("WATCH_ONCE"));
         Thread t = new Thread(() -> {
             while (watching) {
                 try {
@@ -87,6 +92,9 @@ public class ConfigWatchService {
                     // armed; a failed poll is non-fatal to the running app. Pass
                     // the exception so a stack trace is available under DEBUG.
                     log.debug("config watch poll failed", e);
+                }
+                if (watchOnce) {
+                    break; // single long-poll connection for the httpPoll scenario
                 }
             }
         }, "config-watch-poller");


### PR DESCRIPTION
## What

Extends the existing **async-config-poll** sample so it can exercise Keploy's `httpPoll` async-egress lane type ([keploy/keploy#4368](https://github.com/keploy/keploy/pull/4368)), in addition to the current periodic-poller scenario.

- **config-stub**: `POLL_HOLD_SECONDS` (default `0`) holds a `watch=true` request open that long before answering — a server-timeout long-poll. Default `0` preserves the current immediate behavior.
- **ConfigWatchService**: `WATCH_ONCE` (default off) opens exactly one watch poll then stops the daemon, so the recording holds a single long poll rather than a stream. Default off preserves the current infinite poller.
- **keploy-httppoll.yml**: same lane as `keploy.yml` but `type: httpPoll`, so the poll is recorded as `kind: HttpPoll` with an open-duration (`pollDurationMs`) and held until its resolve testcase at replay.

All additions are **env-gated and backward compatible** — the default run is unchanged, so the existing periodic scenario keeps working.

## Why

The keploy `async_config_poll` CI job (in keploy/keploy) is gaining a `scenario: [periodic, httppoll]` matrix so it validates the new `httpPoll` long-poll path end-to-end (record → `kind: HttpPoll` + `pollDurationMs` → replay `held ≥ 1`). That job needs these sample hooks. The matching keploy/keploy change is on PR #4368.

## Validated

Locally against this sample (jdk8 + MySQL + config-stub, keploy built from keploy#4368):
- Record: `1 kind: HttpPoll`, `pollDurationMs: "5027"` (~5s hold), single poll.
- Replay: `test exit 0`, all tests PASSED, async egress verdict `{served: 1, held: 1, shape_flags: 0}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Signed-off-by: Aditya Sharma <aditya282003@gmail.com>