### PR TITLE
feat(async-config-poll): add BLOCK_BOOT_ON_WATCH to block boot on the config watch

### DIFF
--- a/async-config-poll/src/main/java/com/example/asyncconfig/config/ConfigWatchService.java
+++ b/async-config-poll/src/main/java/com/example/asyncconfig/config/ConfigWatchService.java
@@ -58,8 +58,24 @@ public class ConfigWatchService {
         log.info("ConfigWatchService initialized; featuresEnabled={} appConfigVersion={}",
             featuresEnabled, appConfigVersion);
 
-        // (2) Background watch long-poll.
-        startWatchPoller();
+        // (2) Config watch. BLOCK_BOOT_ON_WATCH (replay-only) makes boot BLOCK
+        // synchronously on a watch=true long-poll — the Flipkart shape. With the
+        // old anchor-hold async engine this poll is parked at replay (its
+        // delivery anchored past the reachable window), so the app never becomes
+        // ready = boot deadlock; the value-epoch engine serves the startup epoch
+        // immediately so boot proceeds. When unset (the record path), the watch
+        // runs on a background daemon and does not block boot.
+        if ("true".equalsIgnoreCase(System.getenv("BLOCK_BOOT_ON_WATCH"))) {
+            String url = baseUrl + "/v1/buckets/app-config?watch=true&version=" + appConfigVersion;
+            log.info("BLOCK_BOOT_ON_WATCH: blocking boot on synchronous config watch {}", url);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> resp = rt.getForObject(url, Map.class);
+            log.info("BLOCK_BOOT_ON_WATCH: synchronous config watch returned (version now {}); boot continues",
+                intFrom(resp, "version", appConfigVersion));
+        } else {
+            // Background watch long-poll (record path).
+            startWatchPoller();
+        }
     }
 
     private void startWatchPoller() {


### PR DESCRIPTION
## What & why

Adds an env-gated **`BLOCK_BOOT_ON_WATCH`** mode to `ConfigWatchService` so the app can boot-block on the config-watch long-poll — the shape that exposes the async value-epoch fix in keploy.

Today the sample's config watch runs on a **background daemon** (boot never depends on it), so it can't reproduce the real-world boot deadlock a synchronously-blocking config client hits: at replay the old anchor-hold async engine parks a poll whose delivery is anchored past the reachable test window, and the app never becomes ready.

With `BLOCK_BOOT_ON_WATCH=true`, `init()` performs a **synchronous** `GET /v1/buckets/app-config?watch=true` and blocks boot until it returns:
- **Old (anchor-hold) engine:** the poll is parked → the app never accepts connections → ingress tests fail with `connection refused` (the deadlock).
- **Value-epoch engine:** the startup epoch is served immediately → boot proceeds → tests pass.

When the env is unset (the default / record path, and the existing `periodic` + `httppoll` scenarios), the watch keeps running on the background daemon exactly as before — no behavior change.

## Pairs with

keploy/keploy#4379 (async value-epoch replay). That PR adds a `boot_blocking` cell to the `async-config-poll` e2e which records the app normally and replays it with `BLOCK_BOOT_ON_WATCH=true`, asserting the app boots and the ingress tests pass — i.e. the value-epoch engine serves the startup epoch instead of parking it. That CI cell needs this env support, so this PR should merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
