### PR TITLE
feat(tidb-stmt-cache): add a streamed-BLOB fixture for SEND_LONG_DATA

### DIFF
--- a/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/QueryController.java
+++ b/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/QueryController.java
@@ -43,6 +43,56 @@ public class QueryController {
     }
 
     /**
+     * Streamed-BLOB write on a server-side prepared statement — the sequence
+     * behind keploy/keploy#4262.
+     *
+     * PreparedStatement.setBinaryStream makes Connector/J 8.x send the value
+     * out-of-band and pipeline three commands per re-execution without reading
+     * a response between them:
+     *
+     *   COM_STMT_RESET  ->  COM_STMT_SEND_LONG_DATA  ->  COM_STMT_EXECUTE
+     *
+     * RESET and EXECUTE are each answered with an OK; SEND_LONG_DATA is not
+     * answered at all. A recorder that assumes one response per command pairs
+     * EXECUTE's OK with the wrong request and drops the other, so at replay the
+     * live EXECUTE has no mock and Connector/J fails with
+     * "Can not read response from server".
+     *
+     * Re-executing on a cached statement is what forces the RESET, so this must
+     * be driven more than once on the same connection to reproduce.
+     */
+    @GetMapping("/api/blob/{size}")
+    public Map<String, Object> writeBlob(@PathVariable("size") int size) {
+        byte[] payload = new byte[Math.max(1, Math.min(size, 64 * 1024))];
+        for (int i = 0; i < payload.length; i++) {
+            payload[i] = (byte) (i % 251);
+        }
+
+        Integer id = jdbc.execute((java.sql.Connection conn) -> {
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO blob_stream (payload) VALUES (?)",
+                    java.sql.Statement.RETURN_GENERATED_KEYS)) {
+                // setBinaryStream, not setBytes: the stream setter is what
+                // triggers COM_STMT_SEND_LONG_DATA.
+                ps.setBinaryStream(1, new java.io.ByteArrayInputStream(payload), payload.length);
+                ps.executeUpdate();
+                try (java.sql.ResultSet keys = ps.getGeneratedKeys()) {
+                    return keys.next() ? keys.getInt(1) : -1;
+                }
+            }
+        });
+
+        Integer stored = jdbc.queryForObject(
+                "SELECT LENGTH(payload) FROM blob_stream WHERE id = ?", Integer.class, id);
+
+        Map<String, Object> out = new HashMap<>();
+        out.put("id", id);
+        out.put("sent", payload.length);
+        out.put("stored", stored);
+        return out;
+    }
+
+    /**
      * Lightweight liveness probe. Plain query, no prepared statement --
      * used by the CI script's wait_for_app loop so app readiness is not
      * coupled to TiDB prep-cache behaviour.

--- a/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/SchemaInitializer.java
+++ b/tidb-stmt-cache/src/main/java/com/example/tidbstmtcache/SchemaInitializer.java
@@ -30,5 +30,14 @@ public class SchemaInitializer implements CommandLineRunner {
                 "id INT PRIMARY KEY AUTO_INCREMENT, " +
                 "v INT NOT NULL" +
                 ")");
+
+        // Streamed-BLOB fixture for keploy/keploy#4262. Writing this column
+        // through PreparedStatement.setBinaryStream is what makes Connector/J
+        // pipeline COM_STMT_RESET -> COM_STMT_SEND_LONG_DATA ->
+        // COM_STMT_EXECUTE without reading a response in between.
+        jdbc.execute("CREATE TABLE IF NOT EXISTS blob_stream (" +
+                "id INT PRIMARY KEY AUTO_INCREMENT, " +
+                "payload BLOB NOT NULL" +
+                ")");
     }
 }


### PR DESCRIPTION
## Describe the changes that are made

Adds the fixture that reproduces [keploy/keploy#4262](https://github.com/keploy/keploy/issues/4262).

Writing a BLOB through `PreparedStatement.setBinaryStream` on a server-side prepared statement makes Connector/J 8.x send the value out of band and pipeline three commands per re-execution, without reading a response in between:

```
COM_STMT_RESET  ->  COM_STMT_SEND_LONG_DATA  ->  COM_STMT_EXECUTE
```

A long-sent parameter is **absent from the EXECUTE payload** while still being non-NULL in the null bitmap. A decoder that reads a value for every non-NULL parameter therefore runs off the end and rejects the command — so the EXECUTE never reaches the recorder at all, and replay fails with `Can not read response from server`.

Nothing in the suite wrote a BLOB through a stream setter, which is why the sequence was never recorded.

**`SchemaInitializer`** — adds a `blob_stream` table alongside `kv`.

**`QueryController`** — `GET /api/blob/{size}` inserts a payload with `setBinaryStream` (deliberately not `setBytes`; the stream setter is what triggers `SEND_LONG_DATA`), then reads `LENGTH(payload)` back.

The endpoint must be driven more than once: the `RESET` only appears when the statement is re-executed from Connector/J's cache. This sample already enables that via `useServerPrepStmts=true&cachePrepStmts=true`.

## Verification

Run locally against TiDB with keploy `05b4eada` and with the #4262 fix:

| | keploy 05b4eada | with the fix |
|---|---|---|
| `COM_STMT_EXECUTE` mocks | **0** | **6** |
| `COM_STMT_SEND_LONG_DATA` mocks | 3 | 3 |
| replay (TiDB stopped) | **1 passed / 3 failed** | **4 passed / 0 failed** |
| `Can not read response from server` | 6 occurrences | none |

On the buggy build the EXECUTEs' `OK`s are attributed to the `COM_STMT_RESET` mocks and the EXECUTE requests are dropped entirely — exactly the symptom the issue describes.

## Consumer

The keploy-side PR drives `/api/blob/2048` three times from `.github/workflows/test_workflow_scripts/java/tidb_stmt_cache/java-linux.sh` and asserts on the recorded artifact that `COM_STMT_EXECUTE` mocks exist alongside the `SEND_LONG_DATA` ones — record and replay were wrong in the same direction, so a report-status check alone can pass while the trace is missing every EXECUTE.

**This PR needs to merge first**, otherwise the keploy-side guard runs against an endpoint that does not exist yet.