### PR TITLE
fix(postgres): probe over TCP so dependents aren't released early

### DIFF
--- a/ps-cache-kotlin/docker-compose.yml
+++ b/ps-cache-kotlin/docker-compose.yml
@@ -11,7 +11,21 @@ services:
       - pgdata:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      # -h 127.0.0.1 is load-bearing: it forces a TCP probe.
+      #
+      # Without it pg_isready talks to the Unix socket, and postgres'
+      # docker-entrypoint runs a *temporary* server reachable only over that
+      # socket (listen_addresses='') once initdb has finished, to create the
+      # database and run docker-entrypoint-initdb.d. The socket therefore
+      # answers "accepting connections" while no TCP listener exists at all,
+      # so compose marks this service healthy and depends_on:
+      # service_healthy releases the dependent straight into ECONNREFUSED.
+      #
+      # Short but real: ~235ms with no initdb.d scripts, and 1.2s of
+      # false-healthy plus a 2.7s shutdown checkpoint in the CI failure this
+      # was diagnosed from. Only bites on a fresh volume -- a populated one
+      # skips the temporary server entirely, which is why it failed rarely.
+      test: ["CMD-SHELL", "pg_isready -h 127.0.0.1 -U postgres"]
       interval: 2s
       timeout: 5s
       retries: 5

--- a/sap-demo-java/docker-compose.yml
+++ b/sap-demo-java/docker-compose.yml
@@ -17,7 +17,21 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "customer360", "-d", "customer360"]
+      # -h 127.0.0.1 is load-bearing: it forces a TCP probe.
+      #
+      # Without it pg_isready talks to the Unix socket, and postgres'
+      # docker-entrypoint runs a *temporary* server reachable only over that
+      # socket (listen_addresses='') once initdb has finished, to create the
+      # database and run docker-entrypoint-initdb.d. The socket therefore
+      # answers "accepting connections" while no TCP listener exists at all,
+      # so compose marks this service healthy and depends_on:
+      # service_healthy releases customer360 straight into ECONNREFUSED.
+      #
+      # Short but real: ~235ms with no initdb.d scripts, and 1.2s of
+      # false-healthy plus a 2.7s shutdown checkpoint in the CI failure this
+      # was diagnosed from. Only bites on a fresh volume -- a populated one
+      # skips the temporary server entirely, which is why it failed rarely.
+      test: ["CMD", "pg_isready", "-h", "127.0.0.1", "-U", "customer360", "-d", "customer360"]
       interval: 5s
       timeout: 3s
       retries: 10

--- a/sap-demo-java/k8s/postgres.yaml
+++ b/sap-demo-java/k8s/postgres.yaml
@@ -88,12 +88,21 @@ spec:
               cpu: "500m"
               memory: "256Mi"
           readinessProbe:
+            # Readiness means "can serve clients", so probe over TCP.
+            # Without -h, pg_isready uses the Unix socket, which the
+            # temporary post-initdb server (listen_addresses='') already
+            # answers -- marking the pod Ready while no TCP listener exists
+            # and letting dependents connect to a refused port.
             exec:
-              command: ["pg_isready", "-U", "customer360", "-d", "customer360"]
+              command: ["pg_isready", "-h", "127.0.0.1", "-U", "customer360", "-d", "customer360"]
             periodSeconds: 5
             timeoutSeconds: 3
             failureThreshold: 5
           livenessProbe:
+            # Deliberately the socket probe, unlike readiness above: liveness
+            # asks "is the process alive", and a failure restarts the pod. A
+            # TCP probe here would restart-loop a pod whose initdb outruns
+            # initialDelaySeconds + failureThreshold * periodSeconds.
             exec:
               command: ["pg_isready", "-U", "customer360", "-d", "customer360"]
             initialDelaySeconds: 15


### PR DESCRIPTION
## The bug

`postgres`' `docker-entrypoint` runs a **temporary server reachable only over the Unix socket** (`listen_addresses=''`) once `initdb` has finished, so it can create the database and run `docker-entrypoint-initdb.d`.

A `pg_isready` healthcheck **without `-h`** talks to that socket. So it reports *"accepting connections"* while **no TCP listener exists at all** — compose marks the service healthy, `depends_on: condition: service_healthy` releases the dependent, and the dependent connects straight into `ECONNREFUSED`.

It only bites on a **fresh volume**, because a populated one skips `initdb` and the temporary server entirely. That is why it surfaces as a rare flake rather than a consistent failure.

## Evidence

From the CI failure this was diagnosed from (enterprise `umami-linux`, a matrix cell that creates its volume):

| event | time |
|---|---|
| temp server "ready to accept connections" (socket only) | `08:54:29.422` — false-healthy **begins** |
| fast shutdown request | `08:54:30.668` — window **1.25s** |
| shutdown checkpoint | `08:54:30.780` → `08:54:33.421` (**2.7s**) |
| real TCP listener | after `08:54:33.583` |

compose logged `Container umami_db Waiting` → `Container umami_app Started`, then the app died with `Can't reach database server at 172.78.0.10:5432`, while the db showed `Up 11 seconds (healthy)`.

## Verification

Reproduced and mutation-tested locally with a compose mirroring the `depends_on: service_healthy` shape:

| healthcheck | dependent |
|---|---|
| `pg_isready -U ... -d ...` | `APP_FAILED_TO_REACH_DB`, exit 1 |
| `pg_isready -h 127.0.0.1 -U ... -d ...` | `APP_OK`, exit 0 |

Directly measured the false-healthy window against the patched file: the old check reports healthy from t=2s while TCP is refused until t=8s; the patched check holds `starting` and only goes `healthy` once TCP is genuinely up. Reproduced on **postgres 13.3, 15 and 16**.

## Why `-h 127.0.0.1`

The stock images ship `listen_addresses = '*'`, so the real server binds `0.0.0.0` — one `bind()` covers loopback and the container IP, and the static `ipv4_address` is configured before PID 1 runs, so there is no phase where loopback works and the network IP does not. During startup/recovery `pg_isready` reports *rejecting connections*, so the probe correctly keeps failing until the server can actually serve. `localhost` would be the wrong literal (it may resolve `::1` first).

## Note on `pg_isready` semantics

`pg_isready` is a **liveness** probe: it exits 0 even for a nonexistent role/database, and even when `pg_hba.conf` rejects the connection. The `-U`/`-d` flags here are effectively decorative. That is fine for this fix — the real listener only starts after `initdb` created the role and database — but it does mean the probe is not a substitute for an application-level readiness check.
